### PR TITLE
Found a MalformedJsonExceptions from trailing commas

### DIFF
--- a/src/main/resources/data/bettercompat/recipes/smeltery/melting/amethyst_from_ore.json
+++ b/src/main/resources/data/bettercompat/recipes/smeltery/melting/amethyst_from_ore.json
@@ -10,7 +10,7 @@
   ],
   "type": "tconstruct:ore_melting",
   "ingredient": {
-  	"tag": "forge:ores/amethyst",
+  	"tag": "forge:ores/amethyst"
   },
   "result": {
     "fluid": "bettercompat:molten_amethyst",

--- a/src/main/resources/data/bettercompat/recipes/smeltery/melting/amethyst_from_ore_oab.json
+++ b/src/main/resources/data/bettercompat/recipes/smeltery/melting/amethyst_from_ore_oab.json
@@ -14,7 +14,7 @@
   },
   "type": "tconstruct:ore_melting",
   "ingredient": {
-  	"item": "oresabovediamonds:amethyst_ore",
+  	"item": "oresabovediamonds:amethyst_ore"
   },
   "result": {
     "fluid": "bettercompat:molten_amethyst",

--- a/src/main/resources/data/bettercompat/recipes/smeltery/melting/cincinnasite_from_ore.json
+++ b/src/main/resources/data/bettercompat/recipes/smeltery/melting/cincinnasite_from_ore.json
@@ -14,7 +14,7 @@
   },
   "type": "tconstruct:ore_melting",
   "ingredient": {
-  	"item": "betternether:cincinnasite_ore",
+  	"item": "betternether:cincinnasite_ore"
   },
   "result": {
     "fluid": "bettercompat:molten_cincinnasite",

--- a/src/main/resources/data/bettercompat/recipes/smeltery/melting/ruby_from_ore.json
+++ b/src/main/resources/data/bettercompat/recipes/smeltery/melting/ruby_from_ore.json
@@ -10,7 +10,7 @@
   ],
   "type": "tconstruct:ore_melting",
   "ingredient": {
-  	"tag": "forge:ores/ruby",
+  	"tag": "forge:ores/ruby"
   },
   "result": {
     "fluid": "bettercompat:molten_ruby",

--- a/src/main/resources/data/bettercompat/recipes/smeltery/melting/ruby_from_ore_bn.json
+++ b/src/main/resources/data/bettercompat/recipes/smeltery/melting/ruby_from_ore_bn.json
@@ -14,7 +14,7 @@
   },
   "type": "tconstruct:ore_melting",
   "ingredient": {
-  	"item": "betternether:nether_ruby_ore",
+  	"item": "betternether:nether_ruby_ore"
   },
   "result": {
     "fluid": "bettercompat:molten_ruby",

--- a/src/main/resources/data/bettercompat/recipes/smeltery/melting/sapphire_from_ore.json
+++ b/src/main/resources/data/bettercompat/recipes/smeltery/melting/sapphire_from_ore.json
@@ -10,7 +10,7 @@
   ],
   "type": "tconstruct:ore_melting",
   "ingredient": {
-  	"tag": "forge:ores/sapphire",
+  	"tag": "forge:ores/sapphire"
   },
   "result": {
     "fluid": "bettercompat:molten_sapphire",


### PR DESCRIPTION
This came up in a support forum, lots of stack traces.

There's still an outstanding issue in the `block.json` for Amber.  I couldn't find a quick reference for the `ingredient` attribute as a list.

> Couldn't parse data file bettercompat:tools/materials/amber/block from bettercompat:recipes/tools/materials/amber/block.json
> com.google.gson.JsonParseException: com.google.gson.stream.MalformedJsonException: Expected ':' at line 6 column 4 path $.ingredient.forge:storage_blocks/amber